### PR TITLE
Changed call .distinct() because it caused a bug.

### DIFF
--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -193,7 +193,7 @@ class ImportVariationTestCase(TestCase):
                      variation='benasqués', verbosity=4)
 
         qs = Entry.objects.filter(variation__isnull=False).values(
-            'word__id').order_by('word__id').distinct('word__id')
+            'word__id').order_by('word__id').distinct()
         self.assertEqual(self.NUMBER_OF_ENTRIES, qs.count())
 
     def test_import_invalid_empty_row(self):
@@ -203,7 +203,7 @@ class ImportVariationTestCase(TestCase):
                      variation='benasqués', verbosity=3, stdout=out)
 
         qs = Entry.objects.filter(variation__isnull=False).values(
-            'word__id').order_by('word__id').distinct('word__id')
+            'word__id').order_by('word__id').distinct()
         self.assertEqual(0, qs.count())
         self.assertIn('error', out.getvalue())
 
@@ -215,7 +215,7 @@ class ImportVariationTestCase(TestCase):
                      variation='benasqués', verbosity=4)
 
         qs = Entry.objects.filter(variation__isnull=False).values(
-            'word__id').order_by('word__id').distinct('word__id')
+            'word__id').order_by('word__id').distinct()
         self.assertEqual(FIXTURE_NUMBER_OF_ENTRIES, qs.count())
 
     def test_import_variation_optional_on_dry_run(self):
@@ -223,7 +223,7 @@ class ImportVariationTestCase(TestCase):
         call_command('importvariation', sample_path, dry_run=True, verbosity=4)
 
         qs = Entry.objects.filter(variation__isnull=False).values(
-            'word__id').order_by('word__id').distinct('word__id')
+            'word__id').order_by('word__id').distinct()
         self.assertEqual(0, qs.count())
 
     def test_import_invalid_unkown_gramcat(self):


### PR DESCRIPTION
Changed the call .distinct('word_id') to .distinct() in tests/test_importers.py because calling it with a parameter was causing an error. 

With this change the error does not happen and the test runs correctly and all tests checks result in an 'OK'

**The error migth happen because of one of the next reasons:**

- calling .distinct() with a parameter was supported by another version of postgresql but it is not by this version of postgresql or MySQL.

- the line is trying to use the distinct() only on the values(one column) so it is over necessary to specify the value to use the distinct.


**Links where I found solution for this error:**

[https://stackoverflow.com/questions/54249017/distinct-on-fields-is-not-supported-by-this-database-backend](url)

[https://docs.djangoproject.com/en/2.1/ref/models/querysets/#distinct](url) #(the link to the documentation)


Tracebacks of errors
============

(There were 4 error but I only write the first because all the errors happen because of the same reason and the tracebacks are quite similar)

[errors_that_were_not_written.txt](https://github.com/ribaguifi/linguatec-lexicon/files/5421754/errors_that_were_not_written.txt)

##################################################
ERROR: test_import (tests.test_importers.ImportVariationTestCase)
##################################################
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/home/alejandro/backend_git/tests/test_importers.py", line 197, in test_import
    self.assertEqual(self.NUMBER_OF_ENTRIES, qs.count())
  File "/home/alejandro/backend_proj_env/lib/python3.8/site-packages/django/db/models/query.py", line 392, in count
    return self.query.get_count(using=self.db)
  File "/home/alejandro/backend_proj_env/lib/python3.8/site-packages/django/db/models/sql/query.py", line 504, in get_count
    number = obj.get_aggregation(using, ['__count'])['__count']
  File "/home/alejandro/backend_proj_env/lib/python3.8/site-packages/django/db/models/sql/query.py", line 472, in get_aggregation
    outer_query.add_subquery(inner_query, using)
  File "/home/alejandro/backend_proj_env/lib/python3.8/site-packages/django/db/models/sql/subqueries.py", line 194, in add_subquery
    self.subquery, self.sub_params = query.get_compiler(using).as_sql(with_col_aliases=True)
  File "/home/alejandro/backend_proj_env/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 495, in as_sql
    distinct_result, distinct_params = self.connection.ops.distinct_sql(
  File "/home/alejandro/backend_proj_env/lib/python3.8/site-packages/django/db/backends/base/operations.py", line 172, in distinct_sql
    raise NotSupportedError('DISTINCT ON fields is not supported by this database backend')
django.db.utils.NotSupportedError: DISTINCT ON fields is not supported by this database backend

