### PR TITLE
Updated links in README.txt (git clone 'gitlab' -> 'github')

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with the purpose of host a Spanish to Aragonese dictionary.
 
 Get the app code:
 ```bash
-git clone git@gitlab.com:linguatec/linguatec-lexicon.git
+git clone https://github.com/ribaguifi/linguatec-lexicon.git #old: git@gitlab.com:linguatec/linguatec-lexicon.git
 ```
 
 Create devel project site
@@ -52,7 +52,7 @@ To run the tests, clone the repository, and then:
 # Setup the virtual environment
 virtualenv env
 source env/bin/activate
-git clone git@gitlab.com:linguatec/linguatec-lexicon.git linguatec-lexicon
+git clone https://github.com/ribaguifi/linguatec-lexicon.git linguatec-lexicon #old: git@gitlab.com:linguatec/linguatec-lexicon.git
 cd linguatec-lexicon/
 pip install -r requirements.txt
 pip install .

--- a/docs/admin-guide/README.md
+++ b/docs/admin-guide/README.md
@@ -111,7 +111,7 @@ Setup virtual environment setup for backend:
 
 Get the source and install its particular dependencies:
 
-    git clone https://gitlab.com/linguatec/linguatec-lexicon.git /srv/backend_git
+    git clone https://github.com/ribaguifi/linguatec-lexicon.git /srv/backend_git
     pip3 install -r /srv/backend_git/requirements.txt
     pip3 install -e /srv/backend_git/
 
@@ -186,7 +186,7 @@ Prepare a virtual environment to install the particular packages for the fronten
 
 Get the source and install its particular dependencies:
 
-    git clone https://gitlab.com/linguatec/linguatec-lexicon-frontend /srv/frontend_git
+    git clone https://github.com/ribaguifi/linguatec-lexicon-frontend.git /srv/frontend_git
     pip3 install -r /srv/frontend_git/requirements.txt
     pip3 install -e /srv/frontend_git/
 


### PR DESCRIPTION
Updated the links to the repositories from gitlab (old) to github (new) in the readme files, with the objective to use the git clone commands with the new links.