### PR TITLE
Feature/update endpoint accept lexicon

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,3 +27,12 @@ The `querystring` follows the format described by [Django admin search](https://
 | None	| icontains |
 
 For example, `=foo` should perform a search of `foo` in a case-insensitive **exact** match.
+
+
+### Search words by term
+List the words that have the same term as the value of q parameter. If there is not an exact match it list similar words.
+`GET /words/search/?q=term`
+
+### Search words by term and lexicon
+List the word that have the same term as the value of q parameter and the same lexicon (or lexicon key) as the value of l parameter. If there is not an exact match it list similar words.
+`GET /words/search/?q=term&l=lexicon`

--- a/linguatec_lexicon/management/commands/importvariation.py
+++ b/linguatec_lexicon/management/commands/importvariation.py
@@ -172,7 +172,7 @@ class Command(BaseCommand):
             # 3) trigam similarity (only as suggestion)
             message = 'Word "{}" not found in the database.'.format(term)
             suggestions = None
-            qs = Word.objects.search(term)[:4]
+            qs = Word.objects.search(term,None)[:4]
             if qs.exists():
                 suggestions = ', '.join(qs.values_list('term', flat=True))
                 message += ' Did you mean: {}?'.format(suggestions)

--- a/linguatec_lexicon/management/commands/importvariation.py
+++ b/linguatec_lexicon/management/commands/importvariation.py
@@ -172,7 +172,7 @@ class Command(BaseCommand):
             # 3) trigam similarity (only as suggestion)
             message = 'Word "{}" not found in the database.'.format(term)
             suggestions = None
-            qs = Word.objects.search(term,None)[:4]
+            qs = Word.objects.search(term)[:4]
             if qs.exists():
                 suggestions = ', '.join(qs.values_list('term', flat=True))
                 message += ' Did you mean: {}?'.format(suggestions)

--- a/linguatec_lexicon/models.py
+++ b/linguatec_lexicon/models.py
@@ -51,14 +51,14 @@ class WordManager(models.Manager):
         query = self._clean_search_query(query)
 
         #Get and use the key of the Lexicon instead of the name
-        if lex != None:
+        if lex is not None:
             key_lex = Lexicon.objects.get(name=lex)
 
         if connection.vendor == 'postgresql':
             iregex = r"\y{0}\y"
         elif connection.vendor == 'sqlite':
             iregex=r"\b{0}\b"
-            if lex==None:
+            if lex is None:
                 return self.filter(term__iregex=iregex.format(query))
             else:
                 return self.filter(term__iregex=iregex.format(query),lexicon=key_lex)
@@ -68,13 +68,13 @@ class WordManager(models.Manager):
                 Q(term__startswith=query) |
                 Q(term__endswith=query)
             )
-            if lex==None:
+            if lex is None:
                 return self.filter(filter_query)
             else:
                 return self.filter(filter_query,lexicon=key_lex)
 
         # sort results by trigram similarity
-        if lex==None:
+        if lex is None:
             qs = self.filter(
                     term__iregex=iregex.format(query)
                 ).annotate(similarity=TrigramSimilarity('term', query)

--- a/linguatec_lexicon/models.py
+++ b/linguatec_lexicon/models.py
@@ -51,12 +51,11 @@ class WordManager(models.Manager):
         query = self._clean_search_query(query)
 
         #Get and use the key of the Lexicon instead of the name
-        if lex is not None:
+        if lex is None or lex == '':
+            qs = self
+        else:
             key_lex = Lexicon.objects.get(name=lex)
             qs = self.filter(lexicon=key_lex)
-        else:
-            qs = self
-
         if connection.vendor == 'postgresql':
             iregex = r"\y{0}\y"
         elif connection.vendor == 'sqlite':

--- a/linguatec_lexicon/models.py
+++ b/linguatec_lexicon/models.py
@@ -46,7 +46,7 @@ class WordManager(models.Manager):
 
         return query
 
-    def search(self, query):
+    def search(self, query, lex):
         MIN_SIMILARITY = 0.3
         query = self._clean_search_query(query)
 
@@ -54,18 +54,18 @@ class WordManager(models.Manager):
             iregex = r"\y{0}\y"
         elif connection.vendor == 'sqlite':
             iregex=r"\b{0}\b"
-            return self.filter(term__iregex=iregex.format(query))
+            return self.filter(term__iregex=iregex.format(query),lexicon=lex)
         else:
             filter_query = (
                 Q(term=query) |
                 Q(term__startswith=query) |
                 Q(term__endswith=query)
             )
-            return self.filter(filter_query)
+            return self.filter(filter_query,lexicon=lex)
 
         # sort results by trigram similarity
         qs = self.filter(
-                term__iregex=iregex.format(query)
+                term__iregex=iregex.format(query),lexicon=lex
             ).annotate(similarity=TrigramSimilarity('term', query)
             ).filter(similarity__gt=MIN_SIMILARITY).order_by('-similarity')
         return qs

--- a/linguatec_lexicon/models.py
+++ b/linguatec_lexicon/models.py
@@ -46,7 +46,7 @@ class WordManager(models.Manager):
 
         return query
 
-    def search(self, query, lex):
+    def search(self, query, lex=None):
         MIN_SIMILARITY = 0.3
         query = self._clean_search_query(query)
 

--- a/linguatec_lexicon/views.py
+++ b/linguatec_lexicon/views.py
@@ -110,8 +110,7 @@ class WordViewSet(viewsets.ReadOnlyModelViewSet):
             query = query.strip()
         if lex is not None:
             lex = lex.strip()
-        queryset = Word.objects.search(query,lex) #lex
-
+        queryset = Word.objects.search(query,lex)
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/linguatec_lexicon/views.py
+++ b/linguatec_lexicon/views.py
@@ -105,11 +105,10 @@ class WordViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=False)
     def search(self, request):
         query = self.request.query_params.get('q', None)
-        lex = self.request.query_params.get('l', None)
+        lex = self.request.query_params.get('l', '')
         if query is not None:
             query = query.strip()
-        if lex is not None:
-            lex = lex.strip()
+        lex = lex.strip()
         queryset = Word.objects.search(query, lex)
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/linguatec_lexicon/views.py
+++ b/linguatec_lexicon/views.py
@@ -105,10 +105,12 @@ class WordViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=False)
     def search(self, request):
         query = self.request.query_params.get('q', None)
+        lex = self.request.query_params.get('l', None)
         if query is not None:
             query = query.strip()
-
-        queryset = Word.objects.search(query)
+        if lex is not None:
+            lex = lex.strip()
+        queryset = Word.objects.search(query,lex) #lex
 
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/linguatec_lexicon/views.py
+++ b/linguatec_lexicon/views.py
@@ -110,7 +110,7 @@ class WordViewSet(viewsets.ReadOnlyModelViewSet):
             query = query.strip()
         if lex is not None:
             lex = lex.strip()
-        queryset = Word.objects.search(query,lex)
+        queryset = Word.objects.search(query, lex)
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,14 +16,14 @@ class ApiTestCase(TestCase):
         self.assertEqual(200, resp.status_code)
 
     def test_word_search_with_results(self):
-        resp = self.client.get('/api/words/search/?q=echar')
+        resp = self.client.get('/api/words/search/?q=echar&l=1')
         self.assertEqual(200, resp.status_code)
 
         resp_json = resp.json()
         self.assertEqual(1, resp_json["count"])
 
     def test_word_search_no_results(self):
-        resp = self.client.get('/api/words/search/?q=foo')
+        resp = self.client.get('/api/words/search/?q=foo&l=1')
         self.assertEqual(200, resp.status_code)
 
         resp_json = resp.json()
@@ -79,7 +79,7 @@ class SearchTestCase(TestCase):
                 'gramcatical-categories.json', 'words-search.json']
 
     def do_and_check_query(self, query, expected_results):
-        resp = self.client.get('/api/words/search/?q={}'.format(query))
+        resp = self.client.get('/api/words/search/?q={}&l=1'.format(query))
         self.assertEqual(200, resp.status_code)
 
         expected_results = set(expected_results)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,14 +16,14 @@ class ApiTestCase(TestCase):
         self.assertEqual(200, resp.status_code)
 
     def test_word_search_with_results(self):
-        resp = self.client.get('/api/words/search/?q=echar&l=1')
+        resp = self.client.get('/api/words/search/?q=echar&l=diccionario linguatec')
         self.assertEqual(200, resp.status_code)
 
         resp_json = resp.json()
         self.assertEqual(1, resp_json["count"])
 
     def test_word_search_no_results(self):
-        resp = self.client.get('/api/words/search/?q=foo&l=1')
+        resp = self.client.get('/api/words/search/?q=foo&l=diccionario linguatec')
         self.assertEqual(200, resp.status_code)
 
         resp_json = resp.json()
@@ -79,7 +79,7 @@ class SearchTestCase(TestCase):
                 'gramcatical-categories.json', 'words-search.json']
 
     def do_and_check_query(self, query, expected_results):
-        resp = self.client.get('/api/words/search/?q={}&l=1'.format(query))
+        resp = self.client.get('/api/words/search/?q={}&l=diccionario linguatec'.format(query))
         self.assertEqual(200, resp.status_code)
 
         expected_results = set(expected_results)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -162,15 +162,15 @@ class WordManagerTestCase(TestCase):
     fixtures = ['lexicon-sample.json']
 
     def test_search_found(self):
-        result = Word.objects.search("edad")
+        result = Word.objects.search("edad",1)
         self.assertEqual(1, result.count())
 
     def test_search_not_found(self):
-        result = Word.objects.search("no sense word")
+        result = Word.objects.search("no sense word",1)
         self.assertEqual(0, result.count())
 
     def test_search_null_query(self):
-        result = Word.objects.search(None)
+        result = Word.objects.search(None,1)
         self.assertEqual(0, result.count())
 
     @unittest.skipUnless(connection.vendor == 'postgresql', "requires PostgreSQL backend")
@@ -180,9 +180,9 @@ class WordManagerTestCase(TestCase):
             Word(lexicon_id=1, term="hacer camino"),
             Word(lexicon_id=1, term="hacer"),
         ])
-        result = Word.objects.search("hacer")
+        result = Word.objects.search("hacer",1)
         self.assertEqual(result[0].term, "hacer")
 
     def test_search_query_unbalanced_parenthesis(self):
-        result = Word.objects.search("largo(a")
+        result = Word.objects.search("largo(a",1)
         self.assertEqual(0, result.count())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -162,15 +162,15 @@ class WordManagerTestCase(TestCase):
     fixtures = ['lexicon-sample.json']
 
     def test_search_found(self):
-        result = Word.objects.search("edad",1)
+        result = Word.objects.search("edad","diccionario linguatec")
         self.assertEqual(1, result.count())
 
     def test_search_not_found(self):
-        result = Word.objects.search("no sense word",1)
+        result = Word.objects.search("no sense word","diccionario linguatec")
         self.assertEqual(0, result.count())
 
     def test_search_null_query(self):
-        result = Word.objects.search(None,1)
+        result = Word.objects.search(None,"diccionario linguatec")
         self.assertEqual(0, result.count())
 
     @unittest.skipUnless(connection.vendor == 'postgresql', "requires PostgreSQL backend")
@@ -180,9 +180,9 @@ class WordManagerTestCase(TestCase):
             Word(lexicon_id=1, term="hacer camino"),
             Word(lexicon_id=1, term="hacer"),
         ])
-        result = Word.objects.search("hacer",1)
+        result = Word.objects.search("hacer","diccionario linguatec")
         self.assertEqual(result[0].term, "hacer")
 
     def test_search_query_unbalanced_parenthesis(self):
-        result = Word.objects.search("largo(a",1)
+        result = Word.objects.search("largo(a","diccionario linguatec")
         self.assertEqual(0, result.count())


### PR DESCRIPTION
Updated lexicon API endpoint to accept a new parameter and support multiple lexicon, and updated method Word.objects.search(term) -> Word.objects.search(term,lex)  to accept a lexicon name as a parameter, in order to only search words that belongs to the specified lexicon, unless lex is 'None', in such case the method search will continue taking the words from all the existing lexicons as it was doing before.

Also, the tests which were checking that the urls worked, have been updated, adding a lexicon to search.
For example: client.get('/api/words/search/?q=echar') updated to 
self.client.get('/api/words/search/?q=echar&l=diccionario linguatec') ,where 'diccionario linguatec' is the name of the lexicon where the word was created in (or linked to).

## TODO
- [x] Update `docs/api.md` with new parameter on `search` endpoint.